### PR TITLE
Implement mapping and exporting of custom sounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ for use with Geyser's [custom block API](https://geysermc.org/wiki/geyser/custom
 [custom skulls API](https://geysermc.org/wiki/geyser/custom-skulls), and [custom item API (v2)](https://geysermc.org/wiki/geyser/custom-items). Rainbow is available for Minecraft 26.1.
 
 Rainbow is currently experimental, and capable of generating Geyser block/item mappings, a `custom-skulls.yml` file, and a bedrock resourcepack for
-somewhat simple blocks, 2D and 3D items. For a moderately complete list of Rainbow's capabilities, see further below.
+somewhat simple blocks, 2D and 3D items, and sounds. For a moderately complete list of Rainbow's capabilities, see further below.
 
 Rainbow works by detecting custom blocks (using block state overrides) from loaded resourcepacks, and custom items in your inventory, or a container/inventory menu you have opened.
 It analyses the components of detected items, and uses assets from loaded Java resourcepacks to gather information about block and item models, textures,
@@ -22,12 +22,14 @@ To use Rainbow, you must install it on your Minecraft client. Rainbow adds a few
 you use them as follows:
 
 1. First, start a new pack by running `/rainbow create <name>`, replacing `<name>` with the name of your pack. Your resourcepack and Geyser mappings will be exported in the `.minecraft/rainbow/<name>` folder. Anything in here can be overwritten!
-2. Once you have created a pack, you can start mapping custom blocks, skulls, and items. Mapped custom content will be included in the exported resourcepack and Geyser mappings. There are 5 ways to map custom content:
+2. Once you have created a pack, you can start mapping custom content. Mapped custom content will be included in the exported resourcepack and Geyser mappings. There are multiple ways to map custom content:
    - `/rainbow map block <target>` - maps the custom block at `<target>`, if any.
    - `/rainbow map item` - maps the custom item or skull you're currently holding in your hand, if any.
+   - `/rainbow map sound <namespace>` - maps all the custom sounds of the given namespace.
    - `/rainbow mapinventory` - scans your inventory for custom items or skulls, and maps all that are found.
    - `/rainbow auto blocks` - scans through all loaded resourcepacks for custom blocks created using block state overrides, and maps all that are found. This may shortly freeze your client.
    - `/rainbow auto inventory` - scans all inventory menus and containers you open for custom items and skulls, and maps all that are found. This is handy for plugins that offer an inventory menu listing all custom items. Use `/rainbow auto stop` to stop the mapping of custom items.
+   - `/rainbow auto sounds` - scans through all loaded resourcepacks for custom sounds, and maps all that are found.
 3. Once you have mapped all of your custom items, use `/rainbow finish` to finish the pack. Rainbow will then export the resourcepack and Geyser mappings it has created.
 
 When you've finished your pack, navigate to the `.minecraft/rainbow/<name>` folder. You can also click on the `Wrote pack to disk` in chat to open this folder.
@@ -41,7 +43,7 @@ In this folder, you'll find 5 important files/folders:
 - `report.txt`: you don't need to do anything with this file, but it contains information about generated assets and possible problems that occurred.
 
 Once you have taken these steps, restart your server. Bedrock players should then download the generated pack upon joining,
-and if everything went well, they should be able to see custom content!
+and if everything went well, they should be able to see (and hear) custom content!
 
 If you have any questions or run into any problems, please do feel free to ask for support in the Geyser Discord!
 
@@ -77,6 +79,7 @@ Rainbow is currently capable of the following:
     - Custom elytra items also work, but only visually, due to bedrock limitations.
   - 3D items, by converting the Java model to a bedrock one, and generating an attachable and animations for it, as well as rendering a custom GUI icon.
     - Is able to translate display transformations for the head, first-person and third-person item slots.
+  - Custom sounds.
 - Generating working animated (flipbook) textures for 2D items and 3D items that make use of a single texture only.
 - Exporting merged language files from loaded resourcepacks to a folder, for easy copying to Geyser's `locales/overrides` folder.
   - Files from different resourcepacks for the same language are merged together.

--- a/client/src/main/java/org/geysermc/rainbow/client/ClientAssetResolver.java
+++ b/client/src/main/java/org/geysermc/rainbow/client/ClientAssetResolver.java
@@ -15,6 +15,8 @@ import net.minecraft.client.resources.model.EquipmentClientInfo;
 import net.minecraft.client.resources.model.ModelManager;
 import net.minecraft.client.resources.model.ResolvedModel;
 import net.minecraft.client.resources.model.sprite.AtlasManager;
+import net.minecraft.client.resources.sounds.Sound;
+import net.minecraft.client.resources.sounds.SoundEventRegistration;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.packs.resources.Resource;
@@ -24,6 +26,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.geysermc.rainbow.Rainbow;
 import org.geysermc.rainbow.RainbowIO;
 import org.geysermc.rainbow.client.accessor.ResolvedModelAccessor;
+import org.geysermc.rainbow.client.accessor.SoundManagerAccessor;
 import org.geysermc.rainbow.client.mixin.EntityRenderDispatcherAccessor;
 import org.geysermc.rainbow.client.mixin.SpriteContentsAnimatedTextureAccessor;
 import org.geysermc.rainbow.client.mixin.SpriteContentsClientAccessor;
@@ -104,6 +107,11 @@ public class ClientAssetResolver implements AssetResolver {
     }
 
     @Override
+    public Optional<Resource> getSound(Identifier sound) {
+        return resourceManager.getResource(Sound.SOUND_LISTER.idToFile(sound));
+    }
+
+    @Override
     public Map<String, Map<String, String>> getForeignLanguages() {
         // Ideally we'd not load the language keys again each time, but it's not possible to make use
         // of MC's own language cache here, because MC only loads keys for en_us and the user's language, and,
@@ -142,5 +150,10 @@ public class ClientAssetResolver implements AssetResolver {
             });
         }
         return foreignLanguages;
+    }
+
+    @Override
+    public Map<String, Map<String, SoundEventRegistration>> getSoundRegistrations() {
+        return ((SoundManagerAccessor) Minecraft.getInstance().getSoundManager()).rainbow$getRawRegistrations();
     }
 }

--- a/client/src/main/java/org/geysermc/rainbow/client/ClientPackSerializer.java
+++ b/client/src/main/java/org/geysermc/rainbow/client/ClientPackSerializer.java
@@ -6,13 +6,16 @@ import com.mojang.serialization.DynamicOps;
 import com.mojang.serialization.JsonOps;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.resources.RegistryOps;
+import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.util.Util;
+import org.apache.commons.io.IOUtils;
 import org.geysermc.rainbow.CodecUtil;
 import org.geysermc.rainbow.RainbowIO;
 import org.geysermc.rainbow.mapping.PackSerializer;
 import org.jspecify.annotations.Nullable;
 
 import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
@@ -57,5 +60,17 @@ public class ClientPackSerializer implements PackSerializer {
                 outputTexture.write(texture);
             }
         }), Util.backgroundExecutor().forName("PackSerializer-saveTexture"));
+    }
+
+    @Override
+    public CompletableFuture<?> saveResource(Resource resource, Path path) {
+        return CompletableFuture.runAsync(() -> RainbowIO.safeIO(() -> {
+            CodecUtil.ensureDirectoryExists(path.getParent());
+            try (InputStream input = resource.open()) {
+                try (OutputStream output = new FileOutputStream(path.toFile())) {
+                    IOUtils.copy(input, output);
+                }
+            }
+        }), Util.backgroundExecutor().forName("PackSerializer-saveResource"));
     }
 }

--- a/client/src/main/java/org/geysermc/rainbow/client/PackManager.java
+++ b/client/src/main/java/org/geysermc/rainbow/client/PackManager.java
@@ -141,6 +141,7 @@ which will list any models converted, and any problems that occurred during mapp
         report.append("\nItem texture atlas size: ").append(stats.itemAtlas());
         report.append("\nTerrain texture atlas size: ").append(stats.terrainAtlas());
         report.append("\nFlipbook texture definitions: ").append(stats.flipbookTextures());
+        report.append("\nSound definitions: ").append(stats.soundDefinitions());
         report.append("\n");
         report.append("\nItem attachables exported: ").append(attachables);
         report.append("\n");

--- a/client/src/main/java/org/geysermc/rainbow/client/accessor/SoundManagerAccessor.java
+++ b/client/src/main/java/org/geysermc/rainbow/client/accessor/SoundManagerAccessor.java
@@ -1,0 +1,10 @@
+package org.geysermc.rainbow.client.accessor;
+
+import net.minecraft.client.resources.sounds.SoundEventRegistration;
+
+import java.util.Map;
+
+public interface SoundManagerAccessor {
+
+    Map<String, Map<String, SoundEventRegistration>> rainbow$getRawRegistrations();
+}

--- a/client/src/main/java/org/geysermc/rainbow/client/command/PackGeneratorCommand.java
+++ b/client/src/main/java/org/geysermc/rainbow/client/command/PackGeneratorCommand.java
@@ -82,6 +82,21 @@ public class PackGeneratorCommand {
                                     }
                                 }))
                         )
+                        .then(ClientCommands.literal("sounds")
+                                .then(ClientCommands.argument("namespace", StringArgumentType.word())
+                                        .suggests(SoundNamespaceSuggestionProvider.INSTANCE)
+                                        .executes(context -> {
+                                            String namespace = StringArgumentType.getString(context, "namespace");
+                                            return runWithPack(packManager, (source, pack) -> {
+                                                if (pack.resources().mapSounds(namespace)) {
+                                                    source.sendFeedback(Component.translatable("commands.rainbow.mapped_sounds_of_namespace", namespace));
+                                                } else {
+                                                    source.sendError(Component.translatable("commands.rainbow.no_sounds_mapped"));
+                                                }
+                                            }).run(context);
+                                        })
+                                )
+                        )
                 )
                 .then(ClientCommands.literal("mapinventory")
                         .executes(runWithPack(packManager, (source, pack) -> {
@@ -145,6 +160,15 @@ public class PackGeneratorCommand {
                                 .executes(runWithPack(packManager, (source, _) -> {
                                     packMapper.setItemProvider(InventoryMapper.INSTANCE);
                                     source.sendFeedback(Component.translatable("commands.rainbow.automatic_inventory_mapping"));
+                                }))
+                        )
+                        .then(ClientCommands.literal("sounds")
+                                .executes(runWithPack(packManager, (source, pack) -> {
+                                    if (pack.resources().mapAllSounds()) {
+                                        source.sendFeedback(Component.translatable("commands.rainbow.mapped_all_sounds"));
+                                    } else {
+                                        source.sendError(Component.translatable("commands.rainbow.no_sounds_mapped"));
+                                    }
                                 }))
                         )
                         .then(ClientCommands.literal("stop")

--- a/client/src/main/java/org/geysermc/rainbow/client/command/SoundNamespaceSuggestionProvider.java
+++ b/client/src/main/java/org/geysermc/rainbow/client/command/SoundNamespaceSuggestionProvider.java
@@ -1,0 +1,25 @@
+package org.geysermc.rainbow.client.command;
+
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.commands.SharedSuggestionProvider;
+import net.minecraft.resources.Identifier;
+import org.geysermc.rainbow.client.accessor.SoundManagerAccessor;
+
+import java.util.concurrent.CompletableFuture;
+
+public class SoundNamespaceSuggestionProvider implements SuggestionProvider<FabricClientCommandSource> {
+    public static final SoundNamespaceSuggestionProvider INSTANCE = new SoundNamespaceSuggestionProvider();
+
+    protected SoundNamespaceSuggestionProvider() {}
+
+    @Override
+    public CompletableFuture<Suggestions> getSuggestions(CommandContext<FabricClientCommandSource> context, SuggestionsBuilder builder) {
+
+        return SharedSuggestionProvider.suggest(((SoundManagerAccessor) context.getSource().getClient().getSoundManager()).rainbow$getRawRegistrations().keySet().stream()
+                .filter(namespace -> !namespace.equals(Identifier.DEFAULT_NAMESPACE)), builder);
+    }
+}

--- a/client/src/main/java/org/geysermc/rainbow/client/mixin/SoundManagerMixin.java
+++ b/client/src/main/java/org/geysermc/rainbow/client/mixin/SoundManagerMixin.java
@@ -1,0 +1,34 @@
+package org.geysermc.rainbow.client.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.client.resources.sounds.SoundEventRegistration;
+import net.minecraft.client.sounds.SoundManager;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
+import net.minecraft.util.profiling.ProfilerFiller;
+import org.geysermc.rainbow.client.accessor.SoundManagerAccessor;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Map;
+
+@Mixin(SoundManager.class)
+public abstract class SoundManagerMixin extends SimplePreparableReloadListener<Object> implements SoundManagerAccessor {
+    @Unique
+    private final Map<String, Map<String, SoundEventRegistration>> rawRegistrations = new Object2ObjectOpenHashMap<>();
+
+    @Inject(method = "prepare(Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/util/profiling/ProfilerFiller;)Lnet/minecraft/client/sounds/SoundManager$Preparations;", at = @At(value = "INVOKE", target = "Ljava/util/Map;entrySet()Ljava/util/Set;"))
+    public void storeRawRegistrations(ResourceManager manager, ProfilerFiller profiler, CallbackInfoReturnable<Object> callbackInfoReturnable,
+                                      @Local(name = "namespace") String namespace, @Local(name = "map") Map<String, SoundEventRegistration> map) {
+        rawRegistrations.put(namespace, map);
+    }
+
+    @Override
+    public Map<String, Map<String, SoundEventRegistration>> rainbow$getRawRegistrations() {
+        return rawRegistrations;
+    }
+}

--- a/client/src/main/resources/rainbow-client.mixins.json
+++ b/client/src/main/resources/rainbow-client.mixins.json
@@ -17,6 +17,7 @@
     "defaultRequire": 1
   },
   "mixins": [
-    "ResolvableProfileAccessor"
+    "ResolvableProfileAccessor",
+    "SoundManagerMixin"
   ]
 }

--- a/datagen/src/main/java/org/geysermc/rainbow/datagen/RainbowDataProvider.java
+++ b/datagen/src/main/java/org/geysermc/rainbow/datagen/RainbowDataProvider.java
@@ -4,9 +4,12 @@ import com.google.common.hash.Hashing;
 import com.mojang.blaze3d.platform.NativeImage;
 import com.mojang.serialization.Codec;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.fabricmc.fabric.api.client.datagen.v1.builder.SoundTypeBuilder;
 import net.fabricmc.fabric.api.client.datagen.v1.provider.FabricModelProvider;
+import net.fabricmc.fabric.api.client.datagen.v1.provider.FabricSoundsProvider;
 import net.fabricmc.fabric.api.datagen.v1.FabricPackOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricLanguageProvider;
+import net.fabricmc.fabric.impl.datagen.client.SoundTypeBuilderImpl;
 import net.minecraft.client.data.models.blockstates.BlockModelDefinitionGenerator;
 import net.minecraft.client.data.models.model.ModelInstance;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
@@ -18,6 +21,8 @@ import net.minecraft.client.resources.model.ResolvedModel;
 import net.minecraft.client.resources.model.UnbakedModel;
 import net.minecraft.client.resources.model.cuboid.CuboidModel;
 import net.minecraft.client.resources.model.cuboid.ItemModelGenerator;
+import net.minecraft.client.resources.sounds.Sound;
+import net.minecraft.client.resources.sounds.SoundEventRegistration;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentInitializers;
 import net.minecraft.core.component.DataComponentMap;
@@ -28,15 +33,18 @@ import net.minecraft.data.DataProvider;
 import net.minecraft.data.PackOutput;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.util.ProblemReporter;
 import net.minecraft.util.Util;
+import net.minecraft.util.valueproviders.ConstantFloat;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.equipment.EquipmentAsset;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.geysermc.rainbow.Rainbow;
 import org.geysermc.rainbow.RainbowIO;
+import org.geysermc.rainbow.datagen.accessor.SoundsProviderDataAccessor;
 import org.geysermc.rainbow.datagen.mixin.FabricLanguageProviderAccessor;
 import org.geysermc.rainbow.datagen.accessor.LanguageProviderDataAccessor;
 import org.geysermc.rainbow.datagen.accessor.ModelProviderDataAccessor;
@@ -60,6 +68,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 public abstract class RainbowDataProvider implements DataProvider {
     private static final Logger PROBLEM_LOGGER = LoggerFactory.getLogger(Rainbow.MOD_ID);
@@ -94,7 +103,7 @@ public abstract class RainbowDataProvider implements DataProvider {
 
     protected RainbowDataProvider(FabricPackOutput output, CompletableFuture<HolderLookup.Provider> registries, String packName,
                                   FabricModelProvider modelProvider) {
-        this(output, registries, packName, new Providers(modelProvider, Optional.empty(), Map.of()));
+        this(output, registries, packName, new Providers(modelProvider, Optional.empty(), Optional.empty(), Map.of()));
     }
 
     protected RainbowDataProvider(FabricPackOutput output, CompletableFuture<HolderLookup.Provider> registries, FabricModelProvider modelProvider) {
@@ -108,6 +117,8 @@ public abstract class RainbowDataProvider implements DataProvider {
                 .map(providers -> providers.stream()
                         .map(provider -> provider.run(output))
                         .collect(() -> CompletableFuture.completedFuture(null), CompletableFuture::allOf, CompletableFuture::allOf))
+                .orElseGet(() -> CompletableFuture.completedFuture(null));
+        CompletableFuture<?> sounds = providers.sounds.map(provider -> provider.run(output))
                 .orElseGet(() -> CompletableFuture.completedFuture(null));
 
         CompletableFuture<BedrockPack> bedrockPack = ClientPackLoader.openClientResources()
@@ -127,7 +138,7 @@ public abstract class RainbowDataProvider implements DataProvider {
                     }
                 }));
 
-        return CompletableFuture.allOf(models, languages, bedrockPack.thenCompose(BedrockPack::save));
+        return CompletableFuture.allOf(models, languages, sounds, bedrockPack.thenCompose(BedrockPack::save));
     }
 
     protected BedrockPack.Builder createBedrockPack(PackSerializer serializer, AssetResolver resolver) {
@@ -147,18 +158,22 @@ public abstract class RainbowDataProvider implements DataProvider {
     public static class Providers {
         private final FabricModelProvider models;
         private final Optional<List<FabricLanguageProvider>> languages;
+        private final Optional<FabricSoundsProvider> sounds;
         private final Map<ResourceKey<EquipmentAsset>, EquipmentClientInfo> equipmentInfos;
 
         public Providers(FabricModelProvider models, Optional<List<FabricLanguageProvider>> languages,
+                         Optional<FabricSoundsProvider> sounds,
                          Map<ResourceKey<EquipmentAsset>, EquipmentClientInfo> equipmentInfos) {
             this.models = models;
             this.languages = languages;
+            this.sounds = sounds;
             this.equipmentInfos = equipmentInfos;
         }
 
         public static Providers create(FabricModelProvider models, Optional<FabricLanguageProvider> languages,
+                                       Optional<FabricSoundsProvider> sounds,
                                        Map<ResourceKey<EquipmentAsset>, EquipmentClientInfo> equipmentInfos) {
-            return new Providers(models, languages.map(List::of), equipmentInfos);
+            return new Providers(models, languages.map(List::of), sounds, equipmentInfos);
         }
 
         private Map<Item, ClientItem> getItemInfos() {
@@ -207,6 +222,18 @@ public abstract class RainbowDataProvider implements DataProvider {
                 }
             }, Util.backgroundExecutor().forName("PackSerializer-saveTexture"));
         }
+
+        @Override
+        public CompletableFuture<?> saveResource(Resource resource, Path path) {
+            return CompletableFuture.runAsync(() -> {
+                try (InputStream input = resource.open()) {
+                    byte[] bytes = input.readAllBytes();
+                    output.writeIfNeeded(path, bytes, Hashing.sha1().hashBytes(bytes));
+                } catch (IOException exception) {
+                    LOGGER.error("Failed to save resource to {}", path, exception);
+                }
+            }, Util.backgroundExecutor().forName("PackSerializer-saveResource"));
+        }
     }
 
     private static class DatagenResolver implements AssetResolver {
@@ -218,6 +245,7 @@ public abstract class RainbowDataProvider implements DataProvider {
         private final Map<Identifier, ClientItem> itemInfos;
         private final Map<Identifier, ModelInstance> models;
         private final Map<String, Map<String, String>> foreignLanguages;
+        private final Map<String, Map<String, SoundEventRegistration>> soundRegistrations;
 
         private DatagenResolver(ResourceManager resourceManager, Providers providers) {
             this.resourceManager = resourceManager;
@@ -240,6 +268,15 @@ public abstract class RainbowDataProvider implements DataProvider {
                     return existingKeys;
                 });
             }));
+
+            // Same as above, CompletableFuture should have been finished by now
+            soundRegistrations = providers.sounds.map(sounds -> ((SoundsProviderDataAccessor) sounds).rainbow$getData())
+                    .map(data -> data.entrySet().stream()
+                            .map(registrations -> Map.entry(registrations.getKey(), registrations.getValue().entrySet().stream()
+                                    .map(registration -> Map.entry(registration.getKey(), mapFabricToVanillaRegistration(registration.getValue())))
+                                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))))
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+                    .orElseGet(Map::of);
         }
 
         @Override
@@ -315,8 +352,28 @@ public abstract class RainbowDataProvider implements DataProvider {
         }
 
         @Override
+        public Optional<Resource> getSound(Identifier sound) {
+            // TODO code duplication with ClientAssetResolver
+            return resourceManager.getResource(Sound.SOUND_LISTER.idToFile(sound));
+        }
+
+        @Override
         public Map<String, Map<String, String>> getForeignLanguages() {
             return foreignLanguages;
+        }
+
+        @Override
+        public Map<String, Map<String, SoundEventRegistration>> getSoundRegistrations() {
+            return soundRegistrations;
+        }
+
+        // Cursed? Yes. Works? Also yes
+        private static SoundEventRegistration mapFabricToVanillaRegistration(SoundTypeBuilderImpl.SoundType registration) {
+            return new SoundEventRegistration(registration.sounds().stream()
+                    .map(entry -> new Sound(entry.name(), ConstantFloat.of(entry.volume()), ConstantFloat.of(entry.pitch()),
+                            entry.weight(), entry.type() == SoundTypeBuilder.RegistrationType.FILE? Sound.Type.FILE : Sound.Type.SOUND_EVENT,
+                            entry.stream(), entry.preload(), entry.attenuationDistance()))
+                    .toList(), registration.replace(), registration.subtitle().orElse(null));
         }
     }
 }

--- a/datagen/src/main/java/org/geysermc/rainbow/datagen/accessor/SoundsProviderDataAccessor.java
+++ b/datagen/src/main/java/org/geysermc/rainbow/datagen/accessor/SoundsProviderDataAccessor.java
@@ -1,0 +1,10 @@
+package org.geysermc.rainbow.datagen.accessor;
+
+import net.fabricmc.fabric.impl.datagen.client.SoundTypeBuilderImpl;
+
+import java.util.Map;
+
+public interface SoundsProviderDataAccessor {
+
+    Map<String, Map<String, SoundTypeBuilderImpl.SoundType>> rainbow$getData();
+}

--- a/datagen/src/main/java/org/geysermc/rainbow/datagen/mixin/FabricSoundsProviderMixin.java
+++ b/datagen/src/main/java/org/geysermc/rainbow/datagen/mixin/FabricSoundsProviderMixin.java
@@ -1,0 +1,38 @@
+package org.geysermc.rainbow.datagen.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import net.fabricmc.fabric.api.client.datagen.v1.provider.FabricSoundsProvider;
+import net.fabricmc.fabric.impl.datagen.client.SoundTypeBuilderImpl;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.CachedOutput;
+import net.minecraft.data.DataProvider;
+import org.geysermc.rainbow.datagen.accessor.SoundsProviderDataAccessor;
+import org.jspecify.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+@Mixin(FabricSoundsProvider.class)
+public abstract class FabricSoundsProviderMixin implements DataProvider, SoundsProviderDataAccessor {
+    @Unique
+    private @Nullable Map<String, Map<String, SoundTypeBuilderImpl.SoundType>> data = null;
+
+    @Inject(method = "lambda$run$0", at = @At("RETURN"))
+    public void setData(CachedOutput output, HolderLookup.Provider lookup, CallbackInfoReturnable<CompletionStage> cir,
+                        @Local(name = "data") Map<String, Map<String, SoundTypeBuilderImpl.SoundType>> data) {
+        this.data = data;
+    }
+
+    @Override
+    public Map<String, Map<String, SoundTypeBuilderImpl.SoundType>> rainbow$getData() {
+        if (data == null) {
+            throw new IllegalStateException("FabricSoundsProvider has not run yet");
+        }
+        return data;
+    }
+}

--- a/datagen/src/main/resources/rainbow-datagen.mixins.json
+++ b/datagen/src/main/resources/rainbow-datagen.mixins.json
@@ -14,6 +14,7 @@
   },
   "mixins": [
     "FabricLanguageProviderAccessor",
-    "FabricLanguageProviderMixin"
+    "FabricLanguageProviderMixin",
+    "FabricSoundsProviderMixin"
   ]
 }

--- a/rainbow/src/main/java/org/geysermc/rainbow/mapping/AssetResolver.java
+++ b/rainbow/src/main/java/org/geysermc/rainbow/mapping/AssetResolver.java
@@ -4,9 +4,11 @@ import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.item.ClientItem;
 import net.minecraft.client.resources.model.EquipmentClientInfo;
 import net.minecraft.client.resources.model.ResolvedModel;
+import net.minecraft.client.resources.sounds.SoundEventRegistration;
 import net.minecraft.data.AtlasIds;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.world.item.equipment.EquipmentAsset;
 import net.minecraft.world.level.block.state.BlockState;
 import org.geysermc.rainbow.mapping.texture.TextureResource;
@@ -27,6 +29,8 @@ public interface AssetResolver {
 
     Optional<TextureResource> getTexture(@Nullable Identifier atlas, Identifier identifier);
 
+    Optional<Resource> getSound(Identifier sound);
+
     default Optional<TextureResource> getPossibleAtlasTextureSafely(Identifier identifier) {
         // Vanilla behaviour: when baking a Material, check item atlas first, then block atlas
         // (see ModelManager, MaterialBaker)
@@ -36,4 +40,6 @@ public interface AssetResolver {
     }
 
     Map<String, Map<String, String>> getForeignLanguages();
+
+    Map<String, Map<String, SoundEventRegistration>> getSoundRegistrations();
 }

--- a/rainbow/src/main/java/org/geysermc/rainbow/mapping/PackSerializer.java
+++ b/rainbow/src/main/java/org/geysermc/rainbow/mapping/PackSerializer.java
@@ -1,6 +1,7 @@
 package org.geysermc.rainbow.mapping;
 
 import com.mojang.serialization.Codec;
+import net.minecraft.server.packs.resources.Resource;
 import org.geysermc.rainbow.pack.PackPaths;
 import org.jspecify.annotations.Nullable;
 
@@ -16,6 +17,8 @@ public interface PackSerializer {
     <T> CompletableFuture<?> saveJson(Codec<T> codec, T object, Path path);
 
     CompletableFuture<?> saveTexture(byte[] texture, Path path);
+
+    CompletableFuture<?> saveResource(Resource resource, Path path);
 
     @FunctionalInterface
     interface Serializable {

--- a/rainbow/src/main/java/org/geysermc/rainbow/mapping/PackStats.java
+++ b/rainbow/src/main/java/org/geysermc/rainbow/mapping/PackStats.java
@@ -1,4 +1,4 @@
 package org.geysermc.rainbow.mapping;
 
 public record PackStats(AssetCacheStats cacheStats, int blockMappings, int itemMappings,
-                        int itemAtlas, int terrainAtlas, int flipbookTextures) {}
+                        int itemAtlas, int terrainAtlas, int flipbookTextures, int soundDefinitions) {}

--- a/rainbow/src/main/java/org/geysermc/rainbow/mapping/texture/ModelTextures.java
+++ b/rainbow/src/main/java/org/geysermc/rainbow/mapping/texture/ModelTextures.java
@@ -51,6 +51,6 @@ public interface ModelTextures<T extends ModelTextures<T>> extends PackAssetCach
     }
 
     private static boolean areAllMaterialsTheSame(Map<String, Material> materials) {
-        return materials.values().stream().distinct().count() <= 1L;
+        return materials.values().stream().distinct().count() == 1L;
     }
 }

--- a/rainbow/src/main/java/org/geysermc/rainbow/pack/BedrockPack.java
+++ b/rainbow/src/main/java/org/geysermc/rainbow/pack/BedrockPack.java
@@ -28,6 +28,7 @@ import org.geysermc.rainbow.mapping.PackSerializingContext;
 import org.geysermc.rainbow.mapping.PackStats;
 import org.geysermc.rainbow.mapping.geometry.GeometryRenderer;
 import org.geysermc.rainbow.definition.item.GeyserItemMappings;
+import org.geysermc.rainbow.pack.sound.BedrockSoundDefinitions;
 import org.geysermc.rainbow.pack.texture.BedrockFlipbookTextures;
 import org.geysermc.rainbow.pack.texture.BedrockTextureAtlas;
 import org.geysermc.rainbow.pack.texture.BedrockTextures;
@@ -55,6 +56,7 @@ public class BedrockPack implements BedrockAssetConsumer, PackSerializer.Seriali
     private final BedrockTextures.Builder itemTextures = BedrockTextures.builder();
     private final BedrockTextures.Builder terrainTextures = BedrockTextures.builder();
     private final BedrockFlipbookTextures.Builder flipbookTextures = BedrockFlipbookTextures.builder();
+    private final BedrockSoundDefinitions soundDefinitions;
     private final Set<BedrockBlock> bedrockBlocks = new HashSet<>();
     private final Set<BedrockItem> bedrockItems = new HashSet<>();
     private final Set<Identifier> modelsMapped = new HashSet<>();
@@ -74,6 +76,8 @@ public class BedrockPack implements BedrockAssetConsumer, PackSerializer.Seriali
         // Not reading existing item mappings/texture atlas for now since that doesn't work all that well yet
         this.context = new PackContext(new GeyserMappings(), paths, this, assetResolver, geometryRenderer, reportSuccesses);
         this.reporter = reporter;
+
+        this.soundDefinitions = BedrockSoundDefinitions.tryMapNonVanillaSounds(assetResolver.getSoundRegistrations());
     }
 
     public String name() {
@@ -172,6 +176,7 @@ public class BedrockPack implements BedrockAssetConsumer, PackSerializer.Seriali
                 .with(BedrockTextureAtlas.CODEC, BedrockTextureAtlas.itemAtlas(name, itemTextures), PackPaths::itemAtlas)
                 .with(BedrockTextureAtlas.CODEC, BedrockTextureAtlas.terrainAtlas(name, terrainTextures), PackPaths::terrainAtlas)
                 .with(BedrockFlipbookTextures.CODEC, flipbookTextures.build(), PackPaths::flipbookTextures)
+                .with(soundDefinitions)
                 .with(bedrockBlocks)
                 .with(bedrockItems)
                 .with(paths.languageOutput().map(languageFolder -> context -> LanguageUtil.saveLanguages(context, languageFolder)))
@@ -180,7 +185,7 @@ public class BedrockPack implements BedrockAssetConsumer, PackSerializer.Seriali
 
     public PackStats stats() {
         return new PackStats(context.cacheStats(), context.mappings().blocks().size(), context.mappings().items().size(),
-                itemTextures.build().size(), terrainTextures.build().size(), flipbookTextures.build().size());
+                itemTextures.build().size(), terrainTextures.build().size(), flipbookTextures.build().size(), soundDefinitions.size());
     }
 
     public Set<BedrockItem> getBedrockItems() {

--- a/rainbow/src/main/java/org/geysermc/rainbow/pack/BedrockPack.java
+++ b/rainbow/src/main/java/org/geysermc/rainbow/pack/BedrockPack.java
@@ -1,6 +1,7 @@
 package org.geysermc.rainbow.pack;
 
 import com.mojang.datafixers.util.Pair;
+import net.minecraft.client.resources.sounds.SoundEventRegistration;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponents;
@@ -37,6 +38,7 @@ import org.jspecify.annotations.Nullable;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -56,7 +58,7 @@ public class BedrockPack implements BedrockAssetConsumer, PackSerializer.Seriali
     private final BedrockTextures.Builder itemTextures = BedrockTextures.builder();
     private final BedrockTextures.Builder terrainTextures = BedrockTextures.builder();
     private final BedrockFlipbookTextures.Builder flipbookTextures = BedrockFlipbookTextures.builder();
-    private final BedrockSoundDefinitions soundDefinitions;
+    private final BedrockSoundDefinitions.Builder soundDefinitions = BedrockSoundDefinitions.builder();
     private final Set<BedrockBlock> bedrockBlocks = new HashSet<>();
     private final Set<BedrockItem> bedrockItems = new HashSet<>();
     private final Set<Identifier> modelsMapped = new HashSet<>();
@@ -76,8 +78,6 @@ public class BedrockPack implements BedrockAssetConsumer, PackSerializer.Seriali
         // Not reading existing item mappings/texture atlas for now since that doesn't work all that well yet
         this.context = new PackContext(new GeyserMappings(), paths, this, assetResolver, geometryRenderer, reportSuccesses);
         this.reporter = reporter;
-
-        this.soundDefinitions = BedrockSoundDefinitions.tryMapNonVanillaSounds(assetResolver.getSoundRegistrations());
     }
 
     public String name() {
@@ -141,6 +141,24 @@ public class BedrockPack implements BedrockAssetConsumer, PackSerializer.Seriali
         return mapItem(new ItemStackTemplate(item, 1, patch));
     }
 
+    public boolean mapSounds(String namespace) {
+        Map<String, SoundEventRegistration> sounds = context.assetResolver().getSoundRegistrations().get(namespace);
+        if (sounds == null) {
+            return false;
+        }
+        soundDefinitions.withRegistrations(namespace, sounds);
+        return true;
+    }
+
+    public boolean mapAllSounds() {
+        Map<String, Map<String, SoundEventRegistration>> sounds = context.assetResolver().getSoundRegistrations();
+        if (sounds.isEmpty()) {
+            return false;
+        }
+        soundDefinitions.withRegistrations(sounds);
+        return true;
+    }
+
     public CompletableFuture<?> save() {
         CompletableFuture<?> baseSerialization = save(createSerializingContext());
         if (reporter instanceof AutoCloseable closeable) {
@@ -176,7 +194,7 @@ public class BedrockPack implements BedrockAssetConsumer, PackSerializer.Seriali
                 .with(BedrockTextureAtlas.CODEC, BedrockTextureAtlas.itemAtlas(name, itemTextures), PackPaths::itemAtlas)
                 .with(BedrockTextureAtlas.CODEC, BedrockTextureAtlas.terrainAtlas(name, terrainTextures), PackPaths::terrainAtlas)
                 .with(BedrockFlipbookTextures.CODEC, flipbookTextures.build(), PackPaths::flipbookTextures)
-                .with(soundDefinitions)
+                .with(soundDefinitions.build())
                 .with(bedrockBlocks)
                 .with(bedrockItems)
                 .with(paths.languageOutput().map(languageFolder -> context -> LanguageUtil.saveLanguages(context, languageFolder)))
@@ -185,7 +203,7 @@ public class BedrockPack implements BedrockAssetConsumer, PackSerializer.Seriali
 
     public PackStats stats() {
         return new PackStats(context.cacheStats(), context.mappings().blocks().size(), context.mappings().items().size(),
-                itemTextures.build().size(), terrainTextures.build().size(), flipbookTextures.build().size(), soundDefinitions.size());
+                itemTextures.build().size(), terrainTextures.build().size(), flipbookTextures.build().size(), soundDefinitions.build().size());
     }
 
     public Set<BedrockItem> getBedrockItems() {

--- a/rainbow/src/main/java/org/geysermc/rainbow/pack/PackPaths.java
+++ b/rainbow/src/main/java/org/geysermc/rainbow/pack/PackPaths.java
@@ -1,5 +1,6 @@
 package org.geysermc.rainbow.pack;
 
+import net.minecraft.client.resources.sounds.Sound;
 import net.minecraft.resources.Identifier;
 import org.geysermc.rainbow.Rainbow;
 import org.geysermc.rainbow.mapping.texture.TextureHolder;
@@ -21,6 +22,7 @@ public record PackPaths(Path mappingsRoot, Path packRoot, Optional<Path> zipOutp
     private static final Path ITEM_ATLAS = Path.of("textures/item_texture.json");
     private static final Path TERRAIN_ATLAS = Path.of("textures/terrain_texture.json");
     private static final Path FLIPBOOK_TEXTURES = Path.of("textures/flipbook_textures.json");
+    private static final Path SOUND_DEFINITIONS = Path.of("sounds/sound_definitions.json");
 
     public Path blockMappings() {
         return mappingsRoot.resolve(BLOCK_MAPPINGS);
@@ -51,6 +53,10 @@ public record PackPaths(Path mappingsRoot, Path packRoot, Optional<Path> zipOutp
         return packRoot.resolve(textureIdentifier.getPath());
     }
 
+    public Path sound(Sound sound) {
+        return packRoot.resolve(sound.getPath().getPath());
+    }
+
     public Path manifest() {
         return packRoot.resolve(MANIFEST);
     }
@@ -65,5 +71,9 @@ public record PackPaths(Path mappingsRoot, Path packRoot, Optional<Path> zipOutp
 
     public Path flipbookTextures() {
         return packRoot.resolve(FLIPBOOK_TEXTURES);
+    }
+
+    public Path soundDefinitions() {
+        return packRoot.resolve(SOUND_DEFINITIONS);
     }
 }

--- a/rainbow/src/main/java/org/geysermc/rainbow/pack/sound/BedrockSoundDefinitions.java
+++ b/rainbow/src/main/java/org/geysermc/rainbow/pack/sound/BedrockSoundDefinitions.java
@@ -1,0 +1,98 @@
+package org.geysermc.rainbow.pack.sound;
+
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.client.resources.sounds.Sound;
+import net.minecraft.client.resources.sounds.SoundEventRegistration;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.RandomSource;
+import net.minecraft.util.valueproviders.ConstantFloat;
+import net.minecraft.util.valueproviders.SampledFloat;
+import org.geysermc.rainbow.CodecUtil;
+import org.geysermc.rainbow.mapping.PackSerializer;
+import org.geysermc.rainbow.mapping.PackSerializingContext;
+import org.geysermc.rainbow.pack.PackPaths;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+public record BedrockSoundDefinitions(Map<Identifier, SoundEventRegistration> definitions) implements PackSerializer.Serializable {
+    public static final Codec<Sound> BEDROCK_SOUND_CODEC = RecordCodecBuilder.create(instance ->
+            instance.group(
+                    Codec.STRING.fieldOf("name").forGetter(sound -> "sounds/" + sound.getLocation().getPath()),
+                    Codec.BOOL.optionalFieldOf("stream", false).forGetter(Sound::shouldStream),
+                    Codec.BOOL.optionalFieldOf("is3D", false).forGetter(_ -> true),
+                    createOptionalStaticSampledFloatCodec("volume", 1.0F).forGetter(Sound::getVolume),
+                    createOptionalStaticSampledFloatCodec("pitch", 1.0F).forGetter(Sound::getPitch),
+                    Codec.INT.optionalFieldOf("weight", 1).forGetter(Sound::getWeight)
+            ).apply(instance, (name, stream, _, volume, pitch, weight) ->
+                    new Sound(Identifier.withDefaultNamespace(name.replaceFirst("^sounds/", "")), volume, pitch, weight,
+                            Sound.Type.FILE, stream, false, 16))
+    );
+    public static final Codec<SoundEventRegistration> BEDROCK_REGISTRATION_CODEC = RecordCodecBuilder.create(instance ->
+            instance.group(
+                    Codec.STRING.optionalFieldOf("category", "sound").forGetter(_ -> "sound"),
+                    Codec.FLOAT.optionalFieldOf("min_distance", 0.0F).forGetter(registration -> Float.valueOf(registration.getSounds().stream().map(Sound::getAttenuationDistance).findFirst().orElse(0))),
+                    Codec.FLOAT.optionalFieldOf("max_distance", 0.0F).forGetter(registration -> Float.valueOf(registration.getSounds().stream().map(Sound::getAttenuationDistance).findFirst().orElse(0)) * 2.0F),
+                    BEDROCK_SOUND_CODEC.listOf().fieldOf("sounds").forGetter(SoundEventRegistration::getSounds),
+                    Codec.STRING.optionalFieldOf("subtitle", null).forGetter(SoundEventRegistration::getSubtitle)
+            ).apply(instance, (_, _, _, sounds, subtitle) -> new SoundEventRegistration(sounds, false, subtitle))
+    );
+    public static final Codec<BedrockSoundDefinitions> CODEC = RecordCodecBuilder.create(instance ->
+            instance.group(
+                    CodecUtil.unitVerifyCodec(Codec.STRING, "format_version", "1.20.20"),
+                    Codec.compoundList(Identifier.CODEC, BEDROCK_REGISTRATION_CODEC)
+                            .xmap(pairs -> pairs.stream().collect(Pair.toMap()),
+                                    registrations -> registrations.entrySet().stream().map(entry -> Pair.of(entry.getKey(), entry.getValue())).toList())
+                            .fieldOf("sound_definitions").forGetter(BedrockSoundDefinitions::definitions)
+            ).apply(instance, (_, definitions) -> new BedrockSoundDefinitions(definitions))
+    );
+
+    public int size() {
+        return definitions.size();
+    }
+
+    public Stream<Sound> flatten() {
+        return definitions.values().stream()
+                .flatMap(registration -> registration.getSounds().stream());
+    }
+
+    @Override
+    public CompletableFuture<?> save(PackSerializingContext context) {
+        return PackSerializer.Serializable.wrapCodec(CODEC, this, PackPaths::soundDefinitions)
+                .with(flatten()
+                        .map(BedrockSoundDefinitions::serializableSound)
+                        .toList())
+                .save(context);
+    }
+
+    private static PackSerializer.Serializable serializableSound(Sound sound) {
+        return context -> context.assetResolver().getSound(sound.getLocation())
+                .map(resource -> context.serializer().saveResource(resource, context.paths().sound(sound)))
+                .orElseGet(PackSerializer::noop);
+    }
+
+    private static MapCodec<SampledFloat> createOptionalStaticSampledFloatCodec(String field, float defaultValue) {
+        return Codec.FLOAT.optionalFieldOf(field, defaultValue).xmap(ConstantFloat::of, f -> f.sample(RandomSource.create(0L)));
+    }
+
+    public static BedrockSoundDefinitions tryMapNonVanillaSounds(Map<String, Map<String, SoundEventRegistration>> availableRegistrations) {
+        Map<Identifier, SoundEventRegistration> definitions = new Object2ObjectOpenHashMap<>();
+        for (String namespace : availableRegistrations.keySet()) {
+            if (namespace.equals(Identifier.DEFAULT_NAMESPACE)) {
+                continue;
+            }
+
+            Map<String, SoundEventRegistration> registrations = availableRegistrations.get(namespace);
+            for (Map.Entry<String, SoundEventRegistration> registration : registrations.entrySet()) {
+                definitions.put(Identifier.fromNamespaceAndPath(namespace, registration.getKey()), registration.getValue());
+            }
+        }
+        return new BedrockSoundDefinitions(Collections.unmodifiableMap(definitions));
+    }
+}

--- a/rainbow/src/main/java/org/geysermc/rainbow/pack/sound/BedrockSoundDefinitions.java
+++ b/rainbow/src/main/java/org/geysermc/rainbow/pack/sound/BedrockSoundDefinitions.java
@@ -14,14 +14,15 @@ import net.minecraft.util.valueproviders.SampledFloat;
 import org.geysermc.rainbow.CodecUtil;
 import org.geysermc.rainbow.mapping.PackSerializer;
 import org.geysermc.rainbow.mapping.PackSerializingContext;
+import org.geysermc.rainbow.pack.BedrockVersion;
 import org.geysermc.rainbow.pack.PackPaths;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 public record BedrockSoundDefinitions(Map<Identifier, SoundEventRegistration> definitions) implements PackSerializer.Serializable {
+    public static final BedrockVersion FORMAT_VERSION = BedrockVersion.of(1, 20, 20);
     public static final Codec<Sound> BEDROCK_SOUND_CODEC = RecordCodecBuilder.create(instance ->
             instance.group(
                     Codec.STRING.fieldOf("name").forGetter(sound -> "sounds/" + sound.getLocation().getPath()),
@@ -45,7 +46,7 @@ public record BedrockSoundDefinitions(Map<Identifier, SoundEventRegistration> de
     );
     public static final Codec<BedrockSoundDefinitions> CODEC = RecordCodecBuilder.create(instance ->
             instance.group(
-                    CodecUtil.unitVerifyCodec(Codec.STRING, "format_version", "1.20.20"),
+                    CodecUtil.unitVerifyCodec(BedrockVersion.STRING_CODEC, "format_version", FORMAT_VERSION),
                     Codec.compoundList(Identifier.CODEC, BEDROCK_REGISTRATION_CODEC)
                             .xmap(pairs -> pairs.stream().collect(Pair.toMap()),
                                     registrations -> registrations.entrySet().stream().map(entry -> Pair.of(entry.getKey(), entry.getValue())).toList())
@@ -81,18 +82,33 @@ public record BedrockSoundDefinitions(Map<Identifier, SoundEventRegistration> de
         return Codec.FLOAT.optionalFieldOf(field, defaultValue).xmap(ConstantFloat::of, f -> f.sample(RandomSource.create(0L)));
     }
 
-    public static BedrockSoundDefinitions tryMapNonVanillaSounds(Map<String, Map<String, SoundEventRegistration>> availableRegistrations) {
-        Map<Identifier, SoundEventRegistration> definitions = new Object2ObjectOpenHashMap<>();
-        for (String namespace : availableRegistrations.keySet()) {
-            if (namespace.equals(Identifier.DEFAULT_NAMESPACE)) {
-                continue;
-            }
+    public static Builder builder() {
+        return new Builder();
+    }
 
-            Map<String, SoundEventRegistration> registrations = availableRegistrations.get(namespace);
+    public static class Builder {
+        private final Map<Identifier, SoundEventRegistration> definitions = new Object2ObjectOpenHashMap<>();
+
+        public Builder withRegistrations(String namespace, Map<String, SoundEventRegistration> registrations) {
             for (Map.Entry<String, SoundEventRegistration> registration : registrations.entrySet()) {
                 definitions.put(Identifier.fromNamespaceAndPath(namespace, registration.getKey()), registration.getValue());
             }
+            return this;
         }
-        return new BedrockSoundDefinitions(Collections.unmodifiableMap(definitions));
+
+        public Builder withRegistrations(Map<String, Map<String, SoundEventRegistration>> registrations) {
+            for (String namespace : registrations.keySet()) {
+                if (namespace.equals(Identifier.DEFAULT_NAMESPACE)) {
+                    continue;
+                }
+
+                withRegistrations(namespace, registrations.get(namespace));
+            }
+            return this;
+        }
+
+        public BedrockSoundDefinitions build() {
+            return new BedrockSoundDefinitions(Map.copyOf(definitions));
+        }
     }
 }

--- a/rainbow/src/main/java/org/geysermc/rainbow/pack/sound/package-info.java
+++ b/rainbow/src/main/java/org/geysermc/rainbow/pack/sound/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.geysermc.rainbow.pack.sound;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
This PR implements the mapping and exporting of custom sounds - which is quite simple, given the differences between Java's and bedrock's sound definitions aren't huge. Users are able to optionally map and include all loaded custom sounds when using Rainbow, by running the `/rainbow auto sounds` command. They can also include custom sounds only from certain namespaces, using the `/rainbow map sounds <namespace>` command.

~~Depends on [languages#150](https://github.com/GeyserMC/languages/pull/150)~~ Languages have been pushed to [eclipseisoffline/geyser-languages](https://github.com/eclipseisoffline/geyser-languages) for now, pending Crowdin fixes upstream.

This PR also fixes #34.