### PR TITLE
Support automatically mapping items of item displays

### DIFF
--- a/client/src/main/java/org/geysermc/rainbow/client/command/PackGeneratorCommand.java
+++ b/client/src/main/java/org/geysermc/rainbow/client/command/PackGeneratorCommand.java
@@ -20,6 +20,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 import org.geysermc.rainbow.client.PackManager;
 import org.geysermc.rainbow.client.mapper.InventoryMapper;
+import org.geysermc.rainbow.client.mapper.ItemDisplayMapper;
 import org.geysermc.rainbow.client.mapper.PackMapper;
 import org.geysermc.rainbow.client.mapper.RecipeMapper;
 import org.geysermc.rainbow.pack.BedrockPack;
@@ -161,6 +162,12 @@ public class PackGeneratorCommand {
                                 .executes(runWithPack(packManager, (source, _) -> {
                                     packMapper.setItemProvider(InventoryMapper.INSTANCE);
                                     source.sendFeedback(Component.translatable("commands.rainbow.automatic_inventory_mapping"));
+                                }))
+                        )
+                        .then(ClientCommands.literal("item_display")
+                                .executes(runWithPack(packManager, (source, _) -> {
+                                    packMapper.setItemProvider(ItemDisplayMapper.INSTANCE);
+                                    source.sendFeedback(Component.literal("item display auto mapping activated"));
                                 }))
                         )
                         .then(ClientCommands.literal("recipes")

--- a/client/src/main/java/org/geysermc/rainbow/client/mapper/ItemDisplayMapper.java
+++ b/client/src/main/java/org/geysermc/rainbow/client/mapper/ItemDisplayMapper.java
@@ -1,0 +1,37 @@
+package org.geysermc.rainbow.client.mapper;
+
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.entity.Display;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ItemStackTemplate;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public final class ItemDisplayMapper implements CustomItemProvider {
+    public static final ItemDisplayMapper INSTANCE = new ItemDisplayMapper();
+
+    private ItemDisplayMapper() {}
+
+    @Override
+    public Collection<ItemStackTemplate> nextItems(LocalPlayer player, ClientPacketListener connection) {
+        List<ItemStackTemplate> items = new ArrayList<>();
+        ((ClientLevel) player.level()).entitiesForRendering().forEach(entity -> {
+            if (entity instanceof Display.ItemDisplay itemDisplay) {
+                ItemStack stack = itemDisplay.getItemStack();
+                if (!stack.isEmpty()) {
+                    items.add(ItemStackTemplate.fromNonEmptyStack(stack));
+                }
+            }
+        });
+        return items;
+    }
+
+    @Override
+    public boolean isDone() {
+        return true;
+    }
+}


### PR DESCRIPTION
This PR adds a new command to Rainbow, `/rainbow auto item_display`, which automatically scans all loaded item displays and tries to map any items they hold.

Whilst Geyser does not support item displays natively, extensions exist that do add support for these, such as [GeyserDisplayEntity](https://github.com/GeyserExtensionists/GeyserDisplayEntity). This PR makes it easier to use item displays holding custom items with said extensions

TO-DO: proper language strings and README updates.